### PR TITLE
Add more chains and deterministic deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ The provided contract allows bonding pools to either vouch or invalidate a vouch
 
 The provided contract must be called by the owner of the bonding pools. The owner of a bonding pool is defined as the address that escrowed the initial funding to the bonding pools - in case there are several addresses sending the initial funds to the same bonding pool, the bonding pool can not be considered.
 Calls from other addresses will not be officially indexed and it will not start the allowlisting process for new solvers for the COW-Protocol.
-In case of conflicting vouching votes (e.g. two bonding pools vote for the same solver with different cow reward targets), the first vouch will be seen as the valid one and the second vouch will be disregarded. 
+In case of conflicting vouching votes (e.g. two bonding pools vote for the same solver with different cow reward targets), the first vouch will be seen as the valid one and the second vouch will be disregarded.
 Only updates of currently valid vouches from a bonding pool (e.g. for changing the cowRewardTarget) will be considered.
-Same rules holds true for the invalidation of vouches: If a solver is invalidated by a bonding pool, although the solver is currently not actively vouched by this bonding pool, the message will be disregarded. 
-
+Same rules holds true for the invalidation of vouches: If a solver is invalidated by a bonding pool, although the solver is currently not actively vouched by this bonding pool, the message will be disregarded.
 
 ## Setting up the project
 
@@ -20,18 +19,20 @@ yarn build
 
 ## Deployment
 
-The contract can be deployed on rinkeby-chain by running:
+The contract can be deployed on sepolia-chain by running:
 
 ```sh
 export PK='your PK'
 export INFURA_KEY='your infura key here'
 export GAS_PRICE=10
-yarn deploy --network rinkeby
+yarn deploy --network sepolia
 ```
+
+Regardless of chain and deployer, this should create the contract using CREATE2 at 0xAAA4De096D02AE21729aA31D967E148D4e3Ae501.
 
 ## Verifying on Etherscan:
 
 ```sh
 export ETHERSCAN_API_KEY=<your etherscan api key>
-yarn verify:etherscan --network rinkeby  
+yarn verify:etherscan --network sepolia
 ```

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -9,7 +9,6 @@ import { utils } from "ethers";
 import type { HttpNetworkUserConfig } from "hardhat/types";
 import yargs from "yargs";
 
-
 const argv = yargs
   .option("network", {
     type: "string",
@@ -35,7 +34,7 @@ const DEFAULT_MNEMONIC =
   "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
 
 if (
-  ["rinkeby", "mainnet"].includes(argv.network) &&
+  ["sepolia", "mainnet"].includes(argv.network) &&
   NODE_URL === undefined &&
   INFURA_KEY === undefined
 ) {
@@ -60,7 +59,6 @@ if (GAS_PRICE_GWEI) {
     .parseUnits(GAS_PRICE_GWEI, "gwei")
     .toNumber();
 }
-
 
 export default {
   paths: {
@@ -96,10 +94,20 @@ export default {
       ...sharedNetworkConfig,
       chainId: 100,
     },
-    rinkeby: {
-      url: `https://rinkeby.infura.io/v3/${INFURA_KEY}`,
+    arbitrum: {
+      url: `https://arbitrum.llamarpc.com`,
       ...sharedNetworkConfig,
-      chainId: 4,
+      chainId: 42161,
+    },
+    base: {
+      url: `https://mainnet.base.org`,
+      ...sharedNetworkConfig,
+      chainId: 8453,
+    },
+    sepolia: {
+      url: `https://sepolia.infura.io/v3/${INFURA_KEY}`,
+      ...sharedNetworkConfig,
+      chainId: 11155111,
     },
   },
   namedAccounts: {
@@ -114,9 +122,9 @@ export default {
   },
   etherscan: {
     apiKey: {
-      xdai: "any api key is good currently",
+      gnosis: ETHERSCAN_API_KEY,
       mainnet: ETHERSCAN_API_KEY,
-      rinkeby: ETHERSCAN_API_KEY,
+      sepolia: ETHERSCAN_API_KEY,
     },
   },
 };

--- a/src/deploy/001_deploy.ts
+++ b/src/deploy/001_deploy.ts
@@ -1,23 +1,22 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import {
-    CONTRACT_NAME,
-} from "../ts";
+import { CONTRACT_NAME } from "../ts";
 
 const deployAuthenticator: DeployFunction = async function ({
-    deployments,
-    getNamedAccounts,
+  deployments,
+  getNamedAccounts,
 }: HardhatRuntimeEnvironment) {
-    const { deployer } = await getNamedAccounts();
-    const { deploy } = deployments;
+  const { deployer } = await getNamedAccounts();
+  const { deploy } = deployments;
 
-    await deploy(CONTRACT_NAME, {
-        from: deployer,
-        gasLimit: 2000000,
-        log: true,
-        args: [],
-    });
+  await deploy(CONTRACT_NAME, {
+    from: deployer,
+    gasLimit: 2000000,
+    log: true,
+    args: [],
+    deterministicDeployment: true,
+  });
 };
 
 export default deployAuthenticator;


### PR DESCRIPTION
This PR does two things
1. Add support for relevant networks (remove rinkeby, add sepolia, base & arbitrum)
2. Make deployment deterministic

So that the registry has the same address (0xAAA4De096D02AE21729aA31D967E148D4e3Ae501) on all networks