### PR TITLE
Lens deployment

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -124,6 +124,11 @@ export default {
         ...sharedNetworkConfig,
         chainId: 56,
     },
+    lens: {
+      url: `https://rpc.lens.xyz`,
+      ...sharedNetworkConfig,
+      chainId: 232,
+    },
     sepolia: {
       url: `https://sepolia.infura.io/v3/${INFURA_KEY}`,
       ...sharedNetworkConfig,


### PR DESCRIPTION
The changes required for deployment on Lens.

The contract is there, but not verified, due to the absence of blockscout support.

Upd: it was verified manually